### PR TITLE
Refactoring Dataset and transformations for multiple inputs

### DIFF
--- a/medicaltorch/datasets.py
+++ b/medicaltorch/datasets.py
@@ -371,6 +371,7 @@ class MRI2DSegmentationDataset(Dataset):
             data_dict['input'] = torch.squeeze(torch.stack(input_tensors, dim=0))
             data_dict['input_metadata'] = input_metadata
 
+
         # Warning: both input_tensors and input_metadata are list. Transforms needs to take that into account.
         if self.transform is not None:
             data_dict = self.transform(data_dict)

--- a/medicaltorch/datasets.py
+++ b/medicaltorch/datasets.py
@@ -302,7 +302,6 @@ class MRI2DSegmentationDataset(Dataset):
                                  refresh=False)
 
             training_mean = sum_intensities / numel
-            print("Training means are equal to {}".format(training_mean))
             sum_var = np.array([0.0] * self.n_contrasts)
             numel = np.array([0] * self.n_contrasts)
 
@@ -319,9 +318,6 @@ class MRI2DSegmentationDataset(Dataset):
         # Converting tensors to numpy array
         training_mean = [training_mean[i].item() for i in range(self.n_contrasts)]
         training_std = [training_std[i].item() for i in range(self.n_contrasts)]
-        print("Training means are equal to {}".format(training_mean))
-        print("Training means are equal to {}".format(training_mean))
-
         return training_mean, training_std
 
     def __len__(self):

--- a/medicaltorch/datasets.py
+++ b/medicaltorch/datasets.py
@@ -371,7 +371,6 @@ class MRI2DSegmentationDataset(Dataset):
             data_dict['input'] = torch.squeeze(torch.stack(input_tensors, dim=0))
             data_dict['input_metadata'] = input_metadata
 
-
         # Warning: both input_tensors and input_metadata are list. Transforms needs to take that into account.
         if self.transform is not None:
             data_dict = self.transform(data_dict)

--- a/medicaltorch/datasets.py
+++ b/medicaltorch/datasets.py
@@ -14,8 +14,6 @@ from torch._six import string_classes, int_classes
 
 from PIL import Image
 
-
-
 __numpy_type_map = {
     'float64': torch.DoubleTensor,
     'float32': torch.FloatTensor,
@@ -159,7 +157,7 @@ class SegmentationPair2D(object):
             input_dataobj, gt_dataobj = self.get_pair_data()
         else:
             # use dataobj to avoid caching
-            input_dataobj= [handle.dataobj for handle in self.input_handle]
+            input_dataobj = [handle.dataobj for handle in self.input_handle]
 
             if self.gt_handle is None:
                 gt_dataobj = None
@@ -234,6 +232,7 @@ class MRI2DSegmentationDataset(Dataset):
     :param cache: if the data should be cached in memory or not.
     :param transform: transformations to apply.
     """
+
     def __init__(self, filename_pairs, slice_axis=2, cache=True,
                  transform=None, slice_filter_fn=None, canonical=False):
         self.handlers = []
@@ -264,7 +263,7 @@ class MRI2DSegmentationDataset(Dataset):
 
             for idx_pair_slice in range(input_data_shape[self.slice_axis]):
                 slice_seg_pair = seg_pair.get_pair_slice(idx_pair_slice,
-                                                            self.slice_axis)
+                                                         self.slice_axis)
                 filter_fn_ret_seg = self.slice_filter_fn(slice_seg_pair)
                 if self.slice_filter_fn and not filter_fn_ret_seg:
                     continue
@@ -273,7 +272,7 @@ class MRI2DSegmentationDataset(Dataset):
                 self.indexes.append(item)
 
     def set_transform(self, transform):
-        """This method will replace the current transformation for the
+        """ This method will replace the current transformation for the
         dataset.
 
         :param transform: the new transformation
@@ -281,6 +280,8 @@ class MRI2DSegmentationDataset(Dataset):
         self.transform = transform
 
     def compute_mean_std(self, verbose=False):
+        # TODO: adapt to multi channels
+
         """Compute the mean and standard deviation of the entire dataset.
 
         :param verbose: if True, it will show a progress bar.
@@ -289,8 +290,7 @@ class MRI2DSegmentationDataset(Dataset):
         sum_intensities = 0.0
         numel = 0
 
-        with DatasetManager(self,
-                            override_transform=mt_transforms.ToTensor()) as dset:
+        with DatasetManager(self, override_transform=mt_transforms.ToTensor()) as dset:
             pbar = tqdm(dset, desc="Mean calculation", disable=not verbose)
             for sample in pbar:
                 input_data = sample['input']
@@ -333,43 +333,45 @@ class MRI2DSegmentationDataset(Dataset):
         input_tensors = []
         input_metadata = []
         data_dict = {}
+
+        # Looping over all the inputs (just one or multiple)
         for idx, input_slice in enumerate(seg_pair_slice["input"]):
+
+            # TODO: Check if we can switch to float8 instead
             # Consistency with torchvision, returning PIL Image
             # Using the "Float mode" of PIL, the only mode
             # supporting unbounded float32 values
+
             input_img = Image.fromarray(input_slice, mode='F')
+            input_tensors.append(input_img)
+            input_metadata.append(seg_pair_slice['input_metadata'][idx])
 
-            # Handle unlabeled data
-            if seg_pair_slice["gt"] is None:
-                gt_img = None
-            else:
-                gt_img = Image.fromarray(seg_pair_slice["gt"], mode='F')
+        # Handle unlabeled data
+        if seg_pair_slice["gt"] is None:
+            gt_img = None
+        else:
+            gt_img = Image.fromarray(seg_pair_slice["gt"], mode='F')
 
-            # Handle data with no ROI provided
-            if roi_pair_slice["gt"] is None:
-                roi_img = None
-            else:
-                roi_img = Image.fromarray(roi_pair_slice["gt"], mode='F')
+        # Handle data with no ROI provided
+        if roi_pair_slice["gt"] is None:
+            roi_img = None
+        else:
+            roi_img = Image.fromarray(roi_pair_slice["gt"], mode='F')
 
-            data_dict = {
-                'input': input_img,
-                'gt': gt_img,
-                'roi': roi_img,
-                'input_metadata': seg_pair_slice['input_metadata'][idx],
-                'gt_metadata': seg_pair_slice['gt_metadata'],
-                'roi_metadata': roi_pair_slice['gt_metadata']
-            }
+        data_dict = {
+            'input': input_tensors,  # torch.squeeze(torch.stack(input_tensors, dim=0))
+            'gt': gt_img,
+            'roi': roi_img,
+            'input_metadata': input_metadata,
+            'gt_metadata': seg_pair_slice['gt_metadata'],
+            'roi_metadata': roi_pair_slice['gt_metadata']
+        }
 
-            if self.transform is not None:
-                data_dict = self.transform(data_dict)
-            input_tensors.append(data_dict['input'])
-            input_metadata.append(data_dict['input_metadata'])
-
-        if len(input_tensors) > 1:
-            data_dict['input'] = torch.squeeze(torch.stack(input_tensors, dim=0))
-            data_dict['input_metadata'] = input_metadata
-
+        # Warning: both input_tensors and input_metadata are list. Transforms needs to take that into account.
+        if self.transform is not None:
+            data_dict = self.transform(data_dict)
         return data_dict
+
 
 class MRI3DSegmentationDataset(Dataset):
     """This is a generic class for 3D segmentation datasets.
@@ -379,6 +381,7 @@ class MRI3DSegmentationDataset(Dataset):
     :param cache: if the data should be cached in memory or not.
     :param transform: transformations to apply.
     """
+
     def __init__(self, filename_pairs, cache=True,
                  transform=None, canonical=False):
         self.filename_pairs = filename_pairs
@@ -422,6 +425,7 @@ class MRI3DSegmentationDataset(Dataset):
             data_dict = self.transform(data_dict)
         return data_dict
 
+
 class MRI3DSubVolumeSegmentationDataset(MRI3DSegmentationDataset):
     """This is a generic class for 3D segmentation datasets. This class overload
     MRI3DSegmentationDataset by splitting the initials volumes in several
@@ -443,11 +447,12 @@ class MRI3DSubVolumeSegmentationDataset(MRI3DSegmentationDataset):
     :param length: size of each dimensions of the subvolumes
     :param padding: size of the overlapping per subvolume and dimensions
     """
+
     def __init__(self, filename_pairs, cache=True,
-                 transform=None, canonical=False, length=(64,64,64), padding=0):
+                 transform=None, canonical=False, length=(64, 64, 64), padding=0):
         super().__init__(filename_pairs, cache, transform, canonical)
-        self.length=length
-        self.padding=padding
+        self.length = length
+        self.padding = padding
         self._prepare_indexes()
 
     def _prepare_indexes(self):
@@ -459,21 +464,21 @@ class MRI3DSubVolumeSegmentationDataset(MRI3DSegmentationDataset):
             shape = input_img.shape
             if (shape[0] - 2 * padding) % length[0] != 0 \
                     or (shape[1] - 2 * padding) % length[1] != 0 \
-                    or (shape[2] - 2 * padding) % length[2] != 0 :
+                    or (shape[2] - 2 * padding) % length[2] != 0:
                 raise RuntimeError('Input shape of each dimension should be a \
                                     multiple of length plus 2 * padding')
 
-            for x in range(length[0]+padding, shape[0]-padding+1, length[0]):
-                for y in range(length[1]+padding, shape[1]-padding+1, length[1]):
-                    for z in range(length[2]+padding, shape[2]-padding+1, length[2]):
+            for x in range(length[0] + padding, shape[0] - padding + 1, length[0]):
+                for y in range(length[1] + padding, shape[1] - padding + 1, length[1]):
+                    for z in range(length[2] + padding, shape[2] - padding + 1, length[2]):
                         self.indexes.append({
-                            'x_min': x-length[0]-padding,
-                            'x_max': x+padding,
-                            'y_min': y-length[1]-padding,
-                            'y_max': y+padding,
-                            'z_min': z-length[2]-padding,
-                            'z_max': z+padding,
-                            'handler_index':i})
+                            'x_min': x - length[0] - padding,
+                            'x_max': x + padding,
+                            'y_min': y - length[1] - padding,
+                            'y_max': y + padding,
+                            'z_min': z - length[2] - padding,
+                            'z_max': z + padding,
+                            'handler_index': i})
 
     def __len__(self):
         """Return the dataset size. The number of subvolumes."""
@@ -492,18 +497,18 @@ class MRI3DSubVolumeSegmentationDataset(MRI3DSegmentationDataset):
         }
 
         data_dict['input'] = data_dict['input'][coord['x_min']:coord['x_max'],
-                                coord['y_min']:coord['y_max'],
-                                coord['z_min']:coord['z_max']]
+                             coord['y_min']:coord['y_max'],
+                             coord['z_min']:coord['z_max']]
 
         data_dict['gt'] = data_dict['gt'][coord['x_min']:coord['x_max'],
-                                          coord['y_min']:coord['y_max'],
-                                          coord['z_min']:coord['z_max']]
+                          coord['y_min']:coord['y_max'],
+                          coord['z_min']:coord['z_max']]
 
         if self.transform is not None:
             data_dict = self.transform(data_dict)
 
-        data_dict['input'] = data_dict['input'][None,:,:,:]
-        data_dict['gt'] = data_dict['gt'][None,:,:,:]
+        data_dict['input'] = data_dict['input'][None, :, :, :]
+        data_dict['gt'] = data_dict['gt'][None, :, :, :]
 
         return data_dict
 
@@ -655,7 +660,6 @@ class SCGMChallenge2DTest(MRI2DSegmentationDataset):
             return "site{:d}-sc{:02d}-image.nii.gz".format(site_id, subj_id)
         else:
             return "site{:d}-sc{:02d}-mask-r{:d}.nii.gz".format(site_id, subj_id, rater_id)
-
 
 
 def mt_collate(batch):

--- a/medicaltorch/datasets.py
+++ b/medicaltorch/datasets.py
@@ -346,7 +346,6 @@ class MRI2DSegmentationDataset(Dataset):
             input_tensors.append(input_img)
             input_metadata.append(seg_pair_slice['input_metadata'][idx])
 
-<<<<<<< HEAD
             # Handle unlabeled data
             if seg_pair_slice["gt"] is None:
                 gt_img = None
@@ -378,28 +377,6 @@ class MRI2DSegmentationDataset(Dataset):
         if len(input_tensors) > 1:
             data_dict['input'] = torch.squeeze(torch.stack(input_tensors, dim=0))
             data_dict['input_metadata'] = input_metadata
-=======
-        # Handle unlabeled data
-        if seg_pair_slice["gt"] is None:
-            gt_img = None
-        else:
-            gt_img = Image.fromarray(seg_pair_slice["gt"], mode='F')
-
-        # Handle data with no ROI provided
-        if roi_pair_slice["gt"] is None:
-            roi_img = None
-        else:
-            roi_img = Image.fromarray(roi_pair_slice["gt"], mode='F')
-
-        data_dict = {
-            'input': input_tensors,  # torch.squeeze(torch.stack(input_tensors, dim=0))
-            'gt': gt_img,
-            'roi': roi_img,
-            'input_metadata': input_metadata,
-            'gt_metadata': seg_pair_slice['gt_metadata'],
-            'roi_metadata': roi_pair_slice['gt_metadata']
-        }
->>>>>>> 4d018b91f723ab79974a67a6a3d303b6cb5f0f76
 
         # Warning: both input_tensors and input_metadata are list. Transforms needs to take that into account.
         if self.transform is not None:

--- a/medicaltorch/transforms.py
+++ b/medicaltorch/transforms.py
@@ -37,7 +37,7 @@ class UndoTransform(object):
 
 
 class ToTensor(MTTransform):
-    """Convert a PIL image or numpy array to a PyTorch tensor."""
+    """Convert a PIL image(s) or numpy array(s) to a PyTorch tensor(s)."""
 
     def __init__(self, labeled=True):
         self.labeled = labeled
@@ -47,9 +47,10 @@ class ToTensor(MTTransform):
         input_data = sample['input']
 
         if isinstance(input_data, list):
-            ret_input = [F.to_tensor(item)
-                         for item in input_data]
+            # Multiple inputs
+            ret_input = [F.to_tensor(item) for item in input_data]
         else:
+            # single input
             ret_input = F.to_tensor(input_data)
 
         rdict['input'] = ret_input
@@ -58,15 +59,15 @@ class ToTensor(MTTransform):
             gt_data = sample['gt']
             if gt_data is not None:
                 if isinstance(gt_data, list):
-                    ret_gt = [F.to_tensor(item)
-                              for item in gt_data]
+                    # multiple GT
+                    ret_gt = [F.to_tensor(item) for item in gt_data]
                 else:
+                    # single GT
                     ret_gt = F.to_tensor(gt_data)
 
                 rdict['gt'] = ret_gt
         sample.update(rdict)
         return sample
-
 
 class ToPIL(MTTransform):
     def __init__(self, labeled=True):
@@ -89,8 +90,7 @@ class ToPIL(MTTransform):
         input_data = sample['input']
 
         if isinstance(input_data, list):
-            ret_input = [self.sample_transform(item)
-                         for item in input_data]
+            ret_input = [self.sample_transform(item) for item in input_data]
         else:
             ret_input = self.sample_transform(input_data)
 
@@ -100,8 +100,7 @@ class ToPIL(MTTransform):
             gt_data = sample['gt']
 
             if isinstance(gt_data, list):
-                ret_gt = [self.sample_transform(item)
-                          for item in gt_data]
+                ret_gt = [self.sample_transform(item) for item in gt_data]
             else:
                 ret_gt = self.sample_transform(gt_data)
 
@@ -111,6 +110,7 @@ class ToPIL(MTTransform):
         return sample
 
 
+# useless ??
 class UnCenterCrop2D(MTTransform):
     def __init__(self, size, segmentation=True):
         self.size = size
@@ -600,9 +600,7 @@ class RandomTensorChannelShift(MTTransform):
 
             # Augment just the image, not the mask
             # TODO: fix it later
-            ret_input = []
-            ret_input.append(self.sample_augment(input_data[0], params))
-            ret_input.append(input_data[1])
+            ret_input = [self.sample_augment(input_data[0], params), input_data[1]]
         else:
             ret_input = self.sample_augment(input_data, params)
 

--- a/medicaltorch/transforms.py
+++ b/medicaltorch/transforms.py
@@ -286,10 +286,14 @@ class NormalizeInstance(MTTransform):
 
     def __call__(self, sample):
         input_data = sample['input']
-        for i in range(len(input_data)):
-            mean, std = input_data[i].mean(), input_data[i].std()
-            input_data[i] = F.normalize(input_data[i], [mean], [std])
-
+        if isinstance(input_data, list):
+            for i in range(len(input_data)):
+                mean, std = input_data[i].mean(), input_data[i].std()
+                input_data[i] = F.normalize(input_data[i], [mean], [std])
+        else:
+            mean, std = input_data.mean(), input_data.std()
+            input_data = F.normalize(input_data, [mean], [std])
+        
         rdict = {
             'input': input_data,
         }

--- a/medicaltorch/transforms.py
+++ b/medicaltorch/transforms.py
@@ -94,10 +94,10 @@ class ToPIL(MTTransform):
         rdict = {}
         input_data = sample['input']
 
-        if len(input_data) > 1:
+        if isinstance(input_data, list):
             ret_input = [self.sample_transform(item) for item in input_data]
         else:
-            ret_input = self.sample_transform(input_data[0])
+            ret_input = self.sample_transform(input_data)
 
         rdict['input'] = ret_input
 

--- a/medicaltorch/transforms.py
+++ b/medicaltorch/transforms.py
@@ -4,6 +4,7 @@ import numbers
 import torchvision.transforms.functional as F
 from scipy.ndimage import center_of_mass
 from torchvision import transforms
+import torch
 from PIL import Image
 
 from scipy.ndimage.interpolation import map_coordinates
@@ -112,7 +113,19 @@ class ToPIL(MTTransform):
         return sample
 
 
-# useless ??
+class StackTensors(MTTransform):
+    """
+    Stack all modalities in a single vector.
+    """
+
+    def __call__(self, sample):
+        rdict = {}
+        input_data = sample['input']
+        rdict['input'] = torch.squeeze(torch.stack(input_data, dim=0))
+        sample.update(rdict)
+        return sample
+
+
 class UnCenterCrop2D(MTTransform):
     def __init__(self, size, segmentation=True):
         self.size = size

--- a/medicaltorch/transforms.py
+++ b/medicaltorch/transforms.py
@@ -69,6 +69,7 @@ class ToTensor(MTTransform):
         sample.update(rdict)
         return sample
 
+
 class ToPIL(MTTransform):
     def __init__(self, labeled=True):
         self.labeled = labeled
@@ -414,7 +415,6 @@ class RandomRotation3D(MTTransform):
         rdict['input'] = input_rotated
         if self.labeled:
             rdict['gt'] = gt_rotated
-
         sample.update(rdict)
 
         return sample

--- a/medicaltorch/transforms.py
+++ b/medicaltorch/transforms.py
@@ -69,6 +69,7 @@ class ToTensor(MTTransform):
         sample.update(rdict)
         return sample
 
+
 class ToPIL(MTTransform):
     def __init__(self, labeled=True):
         self.labeled = labeled
@@ -401,7 +402,6 @@ class RandomRotation3D(MTTransform):
             if self.axis == 0:
                 input_rotated[x, :, :] = F.rotate(Image.fromarray(input_data[x, :, :], mode='F'), angle)
                 if self.labeled:
-<<<<<<< HEAD
                     gt_rotated[x, :, :] = F.rotate(Image.fromarray(gt_data[x, :, :], mode='L'), angle)
             if self.axis == 1:
                 input_rotated[:, x, :] = F.rotate(Image.fromarray(input_data[:, x, :], mode='F'), angle)
@@ -415,20 +415,6 @@ class RandomRotation3D(MTTransform):
         rdict['input'] = input_rotated
         if self.labeled:
             rdict['gt'] = gt_rotated
-=======
-                    gt_rotated[x, :, :] = F.rotate(Image.fromarray(gt_data[x, :, :], mode='F'), angle)
-            if self.axis == 1:
-                input_rotated[:, x, :] = F.rotate(Image.fromarray(input_data[:, x, :], mode='F'), angle)
-                if self.labeled:
-                    gt_rotated[:, x, :] = F.rotate(Image.fromarray(gt_data[:, x, :], mode='F'), angle)
-            if self.axis == 2:
-                input_rotated[:, :, x] = F.rotate(Image.fromarray(input_data[:, :, x], mode='F'), angle)
-                if self.labeled:
-                    gt_rotated[:, :, x] = F.rotate(Image.fromarray(gt_data[:, :, x], mode='F'), angle)
-
-        rdict['input'] = input_rotated
-        if self.labeled: rdict['gt'] = gt_rotated
->>>>>>> 4d018b91f723ab79974a67a6a3d303b6cb5f0f76
         sample.update(rdict)
 
         return sample

--- a/medicaltorch/transforms.py
+++ b/medicaltorch/transforms.py
@@ -54,6 +54,8 @@ class ToTensor(MTTransform):
         else:
             # single input
             ret_input = F.to_tensor(input_data[0])
+            # transform list of dic into single dic
+            rdict['input_metadata'] = sample[input_metadata][0]
 
         rdict['input'] = ret_input
 

--- a/medicaltorch/transforms.py
+++ b/medicaltorch/transforms.py
@@ -414,6 +414,7 @@ class RandomRotation3D(MTTransform):
         rdict['input'] = input_rotated
         if self.labeled:
             rdict['gt'] = gt_rotated
+
         sample.update(rdict)
 
         return sample

--- a/medicaltorch/transforms.py
+++ b/medicaltorch/transforms.py
@@ -55,7 +55,7 @@ class ToTensor(MTTransform):
             # single input
             ret_input = F.to_tensor(input_data[0])
             # transform list of dic into single dic
-            rdict['input_metadata'] = sample[input_metadata][0]
+            rdict['input_metadata'] = sample['input_metadata'][0]
 
         rdict['input'] = ret_input
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,6 @@ torch>=0.4.0
 torchvision>=0.2.1
 tqdm>=4.23.0
 scikit-image==0.15.0
+
+pytest>=3.3.2
+pytest-profiling>=1.2.11


### PR DESCRIPTION
As mentioned in #4, the `__getitem__` method in the current dataset returns a single tensor, even if there are multiple modalities. This PR aims to return a list of tensors instead and adapt all transformations to that. 

**N.B.** The dataset returns a list of tensor even if there only one modality (ie a list of one element). But in that case, the transformation `ToTensor()` removes the list and return only the tensor.