### PR TITLE
Multiclass segmentation loader

### DIFF
--- a/medicaltorch/datasets.py
+++ b/medicaltorch/datasets.py
@@ -101,7 +101,7 @@ class SegmentationPair2D(object):
         # Sanity check for dimensions, should be the same
         input_shape, gt_shape = self.get_pair_shapes()
 
-        if self.gt_filenames[0] is not None:
+        if self.gt_filenames is not None:
             if not np.allclose(input_shape, gt_shape):
                 raise RuntimeError('Input and ground truth with different dimensions.')
 
@@ -110,7 +110,7 @@ class SegmentationPair2D(object):
                 self.input_handle[idx] = nib.as_closest_canonical(handle)
 
             # Unlabeled data
-            if self.gt_filenames[0] is not None:
+            if self.gt_filenames is not None:
                 for idx, gt in enumerate(self.gt_handle):
                     if gt is not None:
                         self.gt_handle[idx] = nib.as_closest_canonical(gt)

--- a/medicaltorch/datasets.py
+++ b/medicaltorch/datasets.py
@@ -160,7 +160,7 @@ class SegmentationPair2D(object):
             if gt is not None:
                 gt_data.append(gt.get_fdata(cache_mode, dtype=np.float32))
             else:
-                gt_data.append(np.zeros(self.input_handle[0].shape))
+                gt_data.append(np.zeros(self.input_handle[0].shape, dtype=np.float32))
 
         return input_data, gt_data
 

--- a/medicaltorch/datasets.py
+++ b/medicaltorch/datasets.py
@@ -101,7 +101,7 @@ class SegmentationPair2D(object):
         # Sanity check for dimensions, should be the same
         input_shape, gt_shape = self.get_pair_shapes()
 
-        if self.gt_filenames is not None:
+        if self.gt_filenames[0] is not None:
             if not np.allclose(input_shape, gt_shape):
                 raise RuntimeError('Input and ground truth with different dimensions.')
 
@@ -110,7 +110,7 @@ class SegmentationPair2D(object):
                 self.input_handle[idx] = nib.as_closest_canonical(handle)
 
             # Unlabeled data
-            if self.gt_filenames is not None:
+            if self.gt_filenames[0] is not None:
                 for idx, gt in enumerate(self.gt_handle):
                     if gt is not None:
                         self.gt_handle[idx] = nib.as_closest_canonical(gt)

--- a/medicaltorch/datasets.py
+++ b/medicaltorch/datasets.py
@@ -158,9 +158,9 @@ class SegmentationPair2D(object):
             gt_data = None
         for gt in self.gt_handle:
             if gt is not None:
-                gt_data.append(gt.get_fdata(cache_mode, dtype=np.uint8))
+                gt_data.append(gt.get_fdata(cache_mode, dtype=np.float32))
             else:
-                gt_data.append(np.zeros(self.input_handle[0].shape, dtype=np.uint8))
+                gt_data.append(np.zeros(self.input_handle[0].shape, dtype=np.float32))
 
         return input_data, gt_data
 
@@ -206,13 +206,13 @@ class SegmentationPair2D(object):
             for gt_obj in gt_dataobj:
                 if slice_axis == 2:
                     gt_slices.append(np.asarray(gt_obj[..., slice_index],
-                                          dtype=np.uint8))
+                                          dtype=np.float32))
                 elif slice_axis == 1:
                     gt_slices.append(np.asarray(gt_obj[:, slice_index, ...],
-                                          dtype=np.uint8))
+                                          dtype=np.float32))
                 elif slice_axis == 0:
                     gt_slices.append(np.asarray(gt_obj[slice_index, ...],
-                                          dtype=np.uint8))
+                                          dtype=np.float32))
 
             gt_meta_dict = []
             for gt in self.gt_handle:

--- a/medicaltorch/datasets.py
+++ b/medicaltorch/datasets.py
@@ -388,7 +388,7 @@ class MRI2DSegmentationDataset(Dataset):
             if roi_pair_slice["gt"] is None:
                 roi_img.append(None)
             else:
-                roi_scaled = (roi_pair_slice["gt"] * 255).astype(np.uint8)
+                roi_scaled = (roi_slice * 255).astype(np.uint8)
                 roi_img.append(Image.fromarray(roi_scaled, mode='L'))
 
         data_dict = {

--- a/medicaltorch/transforms.py
+++ b/medicaltorch/transforms.py
@@ -55,9 +55,6 @@ class ToTensor(MTTransform):
             # single input
             ret_input = F.to_tensor(input_data[0])
 
-            # transform list of dic into single dic
-            rdict['input_metadata'] = sample['input_metadata'][0]
-
         rdict['input'] = ret_input
 
         if self.labeled:
@@ -86,9 +83,9 @@ class ToPIL(MTTransform):
         else:
             input_data_npy = sample_data
 
-        input_data_npy = np.transpose(input_data_npy, (1, 2, 0))
-        input_data_npy = np.squeeze(input_data_npy, axis=2)
-        input_data = Image.fromarray(input_data_npy, mode='F')
+        input_data = []
+        for img in input_data_npy:
+            input_data.append(Image.fromarray(img, mode='F'))
         return input_data
 
     def __call__(self, sample):
@@ -127,7 +124,7 @@ class StackTensors(MTTransform):
         rdict = {}
         if isinstance(sample['input'], list):
             input_data = sample['input']
-            rdict['input'] = torch.squeeze(torch.cat(input_data, dim=0))
+            rdict['input'] = torch.cat(input_data, dim=0)
             sample.update(rdict)
         if isinstance(sample['gt'], list):
             gt_data = sample['gt']

--- a/medicaltorch/transforms.py
+++ b/medicaltorch/transforms.py
@@ -125,9 +125,14 @@ class StackTensors(MTTransform):
 
     def __call__(self, sample):
         rdict = {}
-        input_data = sample['input']
-        rdict['input'] = torch.squeeze(torch.cat(input_data, dim=0))
-        sample.update(rdict)
+        if isinstance(sample['input'], list):
+            input_data = sample['input']
+            rdict['input'] = torch.squeeze(torch.cat(input_data, dim=0))
+            sample.update(rdict)
+        if isinstance(sample['gt'], list):
+            gt_data = sample['gt']
+            rdict['gt'] = torch.squeeze(torch.cat(gt_data, dim=0))
+            sample.update(rdict)
         return sample
 
 
@@ -372,7 +377,7 @@ class NormalizeInstance3D(MTTransform):
                                                     [std for _ in range(0, input_volume.shape[0])]).unsqueeze(0)
         rdict = {
             'input': input_data_normalized,
-            'gt': sample['gt'].unsqueeze(0)
+            'gt': [gt.unsqueeze(0) for gt in sample['gt']]
         }
         sample.update(rdict)
         return sample

--- a/medicaltorch/transforms.py
+++ b/medicaltorch/transforms.py
@@ -131,7 +131,7 @@ class StackTensors(MTTransform):
             sample.update(rdict)
         if isinstance(sample['gt'], list):
             gt_data = sample['gt']
-            rdict['gt'] = torch.squeeze(torch.cat(gt_data, dim=0))
+            rdict['gt'] = torch.cat(gt_data, dim=0)
             sample.update(rdict)
         return sample
 


### PR DESCRIPTION
Adapt loader and transformations to allow multiclass segmentation. As it is done for inputs, ground truths are now stored in a list of the length of the number of classes. If for a subject one label is absent, an empty tensor is used for the specific label. For now, the background class is not generated in the loader.

Related PR in ivado-medical-imaging: https://github.com/neuropoly/ivado-medical-imaging/pull/160